### PR TITLE
Get CI off of about-to-be-removed Ubuntu 20.04

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   clang-format:
     name: Enforce clang-format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CLANG_MAJOR_VERSION: 19
     steps:

--- a/.github/workflows/linux-mingw.yml
+++ b/.github/workflows/linux-mingw.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   linux-mingw:
     name: Build on Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/linux-mingw.yml
+++ b/.github/workflows/linux-mingw.yml
@@ -64,8 +64,8 @@ jobs:
           COPYING \
           README.md \
           /usr/i686-w64-mingw32/lib/libwinpthread-1.dll \
-          /usr/lib/gcc/i686-w64-mingw32/9.3-posix/libgcc_s_sjlj-1.dll \
-          /usr/lib/gcc/i686-w64-mingw32/9.3-posix/libstdc++-6.dll \
+          /usr/lib/gcc/i686-w64-mingw32/*-posix/libgcc_s_dw2-1.dll \
+          /usr/lib/gcc/i686-w64-mingw32/*-posix/libstdc++-6.dll \
           build/visdriver.exe \
           "visdriver_win32bin_mingw_${{ github.sha }}"/
 

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ Please report bugs at https://github.com/hartwork/visdriver -- thank you!
 ```
 
 If you end up with errors about missing DLLs, copying these files in place
-should help.  E.g. for MinGW DLLs on Ubuntu 20.04 it would be:
+should help.  E.g. for MinGW DLLs on Ubuntu 24.04 it would be:
 
 ```console
 # cp -v \
     /usr/i686-w64-mingw32/lib/libwinpthread-1.dll \
-    /usr/lib/gcc/i686-w64-mingw32/9.3-posix/libgcc_s_sjlj-1.dll \
-    /usr/lib/gcc/i686-w64-mingw32/9.3-posix/libstdc++-6.dll \
+    /usr/lib/gcc/i686-w64-mingw32/*-posix/libgcc_s_dw2-1.dll \
+    /usr/lib/gcc/i686-w64-mingw32/*-posix/libstdc++-6.dll \
     .
 ```
 


### PR DESCRIPTION
Ubuntu 20.04 is about to be removed on 2025-04-01.